### PR TITLE
Parallel simulation and data transfer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -88,9 +88,12 @@ fn main() {
     // each u32 represents a color: 8 bits of nothing, then 8 bits each of R, G, B
     let mut image_hostbuffer = vec![0u32; WINDOW_WIDTH * WINDOW_HEIGHT];
 
-    /* @todo do a single render + read + display here; this way, if the program starts paused, we display the
-    initial fluid state instead of a blank screen.
-    */
+    // Display the initial state, so that the window isn't blank if the program is paused on startup.
+    unsafe { render_kernel.enq().unwrap(); }
+    image.read(&mut image_hostbuffer)
+        .queue(render_kernel.default_queue().unwrap()) // use same queue, so read waits for render to complete
+        .enq().unwrap();
+    graphics_context.set_buffer(&image_hostbuffer, WINDOW_WIDTH as u16, WINDOW_HEIGHT as u16);
 
     // set up communication channels
     let (pause_toggle_tx, pause_toggle_rx) = mpsc::sync_channel::<()>(0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,9 +25,9 @@ const RENDER_INTERVAL: f32 = 1. / RENDER_FPS;
 const WINDOW_HEIGHT: usize = ((SPATIAL_DOMAIN_SIZE_Y / SPATIAL_DOMAIN_SIZE_X) * WINDOW_WIDTH as f32) as usize;
 
 use std::{
-    fs::File,
-    io::Read,
-    time::{self, Duration}, sync::mpsc::{self, TryRecvError, TrySendError}, thread,
+    time::{self, Duration},
+    sync::mpsc::{self, TryRecvError, TrySendError},
+    thread,
 };
 
 use ocl::{
@@ -102,10 +102,10 @@ fn main() {
     channel buffer size 1 so that the simulation thread can non-blockingly send back the render status event
     and continue feeding simulation commands to the hungry GPU
     */
-    let (render_status_tx, render_status_rx) = mpsc::sync_channel::<ocl::EventList>(1); // @todo probably want EventList here
+    let (render_status_tx, render_status_rx) = mpsc::sync_channel::<ocl::EventList>(1);
 
     // set up simulation thread
-    let sim_and_render_thread = thread::spawn(move || {
+    let _sim_and_render_thread = thread::spawn(move || {
         let mut iter = 0;
         let mut iter_display_timer = time::Instant::now();
 


### PR DESCRIPTION
- Splits simulation and image copies into separate command queues, so that they can happen in parallel.
- Create a dedicated thread for enqueueing simulation commands, so that (1) simulation isn't unnecessarily tied to the event loop, and (2) we can keep feeding the GPU with simulation commands without blocking on unrelated work like handling keypresses and redraw requests.

